### PR TITLE
added history unlisten on source dispose with test

### DIFF
--- a/src/makeHistoryDriver.js
+++ b/src/makeHistoryDriver.js
@@ -75,7 +75,13 @@ function makeHistoryDriver(history, options) {
   /*eslint-enable*/
   return function historyDriver(sink$) {
     let history$ = new ReplaySubject(1)
-    history.listen(location => history$.onNext(location))
+    let unlisten = history.listen(location => history$.onNext(location))
+
+    let _dispose = history$.dispose
+    history$.dispose = () => {
+      unlisten()
+      _dispose.apply(history$)
+    }
 
     sink$.subscribe(makeUpdateHistory(history))
 

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -130,5 +130,21 @@ describe(`History`, () => {
         sources.dispose()
       })
     })
+
+    it(`should stop listening history after disposed`, (done) => {
+      const app = () => ({})
+      const history = createHashHistory()
+      const {sources} = run(app, {
+        history: makeHistoryDriver(history)
+      })
+
+      setTimeout(function(){
+        sources.dispose()
+        assert.doesNotThrow(function(){
+          history.push(`/something`)
+          done()
+        }, Error, `does not throw after disposed`)
+      })
+    })
   })
 })


### PR DESCRIPTION
Without this after sources disposed passed history object may process operations, and if driver will continue listening it will throw, because subject is disposed (and this is kinda leak).

This is applicable for hot-reloading scenarios, where sources and sinks may be disposed multiple times while page lifecycle.