### PR TITLE
feat(History3.0): Adapt to history 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
   },
   "homepage": "https://github.com/cyclejs/history#readme",
   "dependencies": {
-    "history": "^2.1.0"
+    "history": "^3.0.0-2"
   },
   "devDependencies": {
     "@cycle/base": "^2.0.1",
     "@cycle/dom": "^10.0.0-rc8",
     "@cycle/rx-adapter": "^1.0.3",
     "@cycle/rxjs-adapter": "^1.0.5",
-    "@cycle/xstream-adapter": "^1.0.2",
+    "@cycle/xstream-adapter": "^1.0.3",
     "@cycle/xstream-run": "^1.0.0",
     "assert": "^1.3.0",
     "babel-preset-es2015": "^6.6.0",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -27,9 +27,9 @@ export interface History {
   replace(location: Location| Pathname): void;
   createHref(href: Pathname): string;
   createLocation(location: Location | Pathname): Location;
-
   addCompleteCallback?: (fn: () => void) => void;
   complete?: () => void;
+  getCurrentLocation(): Location;
 };
 
 export interface HistoryDriverOptions {

--- a/src/makeHistoryDriver.ts
+++ b/src/makeHistoryDriver.ts
@@ -33,9 +33,11 @@ export function makeHistoryDriver(history: History, options?: HistoryDriverOptio
     || typeof history.createLocation !== 'function'
     || typeof history.createHref !== 'function'
     || typeof history.listen !== 'function'
-    || typeof history.push !== 'function') {
+    || typeof history.push !== 'function'
+    || typeof history.getCurrentLocation !== 'function') {
     throw new TypeError('makeHistoryDriver requires an valid history object ' +
-      'containing createLocation(), createHref(), push(), and listen() methods');
+      'containing createLocation(), createHref(), push(), ' +
+      'getCurrentLocation(), and listen() methods');
   }
   const capture: boolean = options && options.capture || false;
   const onError: (err: Error) => void = options && options.onError || defaultOnErrorFn;
@@ -68,6 +70,8 @@ export function makeHistoryDriver(history: History, options?: HistoryDriverOptio
         history.push(location);
       });
     }
+
+    observer.next(history.getCurrentLocation());
 
     stream.createHref = history.createHref;
     stream.createLocation = history.createLocation;

--- a/src/serverHistory.ts
+++ b/src/serverHistory.ts
@@ -6,7 +6,7 @@ class ServerHistory implements History {
   private listeners: Array<Listener>;
   private _completeCallback: () => void;
 
-  constructor() {
+  constructor(private currentLocation: Location) {
     this.listeners = [];
   }
 
@@ -20,7 +20,7 @@ class ServerHistory implements History {
     if (length === 0) {
       throw new Error('Must be given at least one listener before pushing');
     }
-
+    this.currentLocation = createLocation(location);
     for (let i = 0; i < length; ++i) {
       this.listeners[i](createLocation(location));
     }
@@ -45,8 +45,15 @@ class ServerHistory implements History {
   complete() {
     this._completeCallback();
   }
+
+  getCurrentLocation() {
+    return this.currentLocation;
+  }
 }
 
-export function createServerHistory(): History {
-  return new ServerHistory();
+export function createServerHistory(currentLocation: Location | Pathname): History {
+  if (currentLocation === void 0) {
+    throw new Error('ServerHistory needs an initial location passed in as a parameter');
+  }
+  return new ServerHistory(createLocation(currentLocation));
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,7 +27,6 @@ const locationDefaults: Location = {
   action: 'POP',
   hash: '',
   search: '',
-  state: null,
   key: null,
   query: null,
 };

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -15,7 +15,6 @@ const locationDefaults = {
   action: 'POP',
   hash: '',
   search: '',
-  state: null,
   key: null,
   query: null,
 };
@@ -49,22 +48,23 @@ describe('History', () => {
 
   describe('createServerHistory', () => {
     it(`should be an object`, () => {
-      const history = createServerHistory();
+      const history = createServerHistory('/path');
       assert.strictEqual(typeof history, `object`);
       assert.strictEqual(typeof history.push, `function`);
       assert.strictEqual(typeof history.listen, `function`);
       assert.strictEqual(typeof history.replace, `function`);
+      assert.strictEqual(typeof history.getCurrentLocation, `function`);
     });
 
     it(`should return a function when .listen() is called`, () => {
-      const history = createServerHistory();
+      const history = createServerHistory('/path');
       const unlisten = history.listen(() => { return void 0; });
       assert.strictEqual(typeof unlisten, `function`);
       unlisten();
     });
 
     it(`should allow pushing locations`, (done) => {
-      const history = createServerHistory();
+      const history = createServerHistory('/path');
       history.listen(location => {
         assert.strictEqual(typeof location, `object`);
         assert.strictEqual(location.pathname, `/some/path`);
@@ -74,16 +74,16 @@ describe('History', () => {
     });
 
     it(`should create an href`, () => {
-      const history = createServerHistory();
+      const history = createServerHistory('/path');
       assert.strictEqual(history.createHref(`/some/path`), `/some/path`);
     });
 
     it(`should create a location`, () => {
-      const history = createServerHistory();
+      const history = createServerHistory('/path');
       const location = history.createLocation(`/some/path`);
       assert.strictEqual(typeof location, `object`);
       assert.strictEqual(location.pathname, `/some/path`);
-      assert.strictEqual(location.state, null);
+      assert.strictEqual(typeof location.state, `undefined`);
       assert.strictEqual(location.query, null);
     });
   });
@@ -97,7 +97,7 @@ describe('History', () => {
 
     it(`should return a stream with createHref() and createLocation() methods`,
       () => {
-        const history = createServerHistory();
+        const history = createServerHistory('/path');
         const history$ = makeHistoryDriver(history)(xs.of(`/`), XSAdapter);
 
         assert.strictEqual(history$ instanceof xs, true);
@@ -106,14 +106,14 @@ describe('History', () => {
       });
 
     it('should allow pushing to a history object', (done) => {
-      const history = createServerHistory();
+      const history = createServerHistory('/path');
       const app = () => ({})
       const {sources, run} = Cycle(app, {
         history: makeHistoryDriver(history)
       })
 
       let dispose;
-      sources.history.addListener({
+      sources.history.drop(1).addListener({
         next(location) {
           assert.strictEqual(location.pathname, '/test');
           setTimeout(() => {
@@ -132,15 +132,15 @@ describe('History', () => {
     it(`should return a location to application`, (done) => {
       const app = () => ({history: xs.of(`/`)});
       const {sources, run} = Cycle(app, {
-        history: makeHistoryDriver(createServerHistory()),
+        history: makeHistoryDriver(createServerHistory('/path')),
       });
 
       let dispose;
-      sources.history.addListener({
+      sources.history.drop(1).addListener({
         next: (location) => {
           assert.strictEqual(typeof location, `object`);
           assert.strictEqual(location.pathname, `/`);
-          assert.strictEqual(location.state, null);
+          assert.strictEqual(typeof location.state, `undefined`);
           setTimeout(() => {
             dispose();
             done();
@@ -160,15 +160,15 @@ describe('History', () => {
         }),
       });
       const {sources, run} = Cycle(app, {
-        history: makeHistoryDriver(createServerHistory()),
+        history: makeHistoryDriver(createServerHistory('/path')),
       });
 
       let dispose;
-      sources.history.addListener({
+      sources.history.drop(1).addListener({
         next(location) {
           assert.strictEqual(typeof location, `object`);
           assert.strictEqual(location.pathname, `/`);
-          assert.strictEqual(location.state, null);
+          assert.strictEqual(typeof location.state, `undefined`);
           setTimeout(() => {
             dispose();
             done();
@@ -181,10 +181,10 @@ describe('History', () => {
     });
   });
 
-  it('should allow killing the stream with serverHistory.complete()', () => {
+  it('should allow killing the stream with serverHistory.complete()', (done) => {
     const app = () => ({});
 
-    const history = createServerHistory();
+    const history = createServerHistory('/path');
     const {sources, run} = Cycle(app, {
       history: makeHistoryDriver(history),
     });
@@ -211,7 +211,30 @@ describe('History', () => {
     });
     dispose = run();
 
-    history.push('/path');
     history.push('/other');
+  });
+
+  it(`should be initiated with the location passed to createServerHistory`, (done) => {
+    const app = () => ({})
+
+    const {sources, run} = Cycle(app, {
+      history: makeHistoryDriver(createServerHistory('/path')),
+    })
+
+    let dispose;
+    sources.history.addListener({
+      next(location) {
+        assert.strictEqual(typeof location, `object`);
+        assert.strictEqual(location.pathname, '/path')
+        assert.strictEqual(typeof location.state, `undefined`);
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      },
+      error() { return void 0; },
+      complete() { return void 0; },
+    })
+    dispose = run();
   });
 });


### PR DESCRIPTION
BREAKING: `createServerHistory()` now takes a Location | Pathname as a
parameter and emits immidiately on sources stream.
BREAKING: `makeHistoryDriver()` requires a history object with
`.getCurrentLocation()` method.
BREAKING: `Location.state` is no longer null if not defined but `undefined` see https://github.com/mjackson/history/blob/master/CHANGES.md
